### PR TITLE
Document mock env reuse and guard empty config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Follow these steps to drive the daemon by hand with synthetic temperatures:
    ```sh
    USE_MOCK_NVML=1 make build
    export NVML_MOCK_DIR="$(mktemp -d)"
+   # Copy this export line into any additional shells that need to talk to the mock backend.
+   printf 'export NVML_MOCK_DIR=%q\n' "$NVML_MOCK_DIR"
    ```
 2. Launch the daemon with any config (the test fixtures are handy starting
    points):
@@ -101,9 +103,11 @@ Follow these steps to drive the daemon by hand with synthetic temperatures:
 3. In another terminal, set fake temperatures and tail the mock fan-speed log
    using the helper script:
    ```sh
-   NVML_MOCK_DIR="$NVML_MOCK_DIR" mock_nvml/mockctl.sh set-temp 35
-   NVML_MOCK_DIR="$NVML_MOCK_DIR" mock_nvml/mockctl.sh set-temp 70
-   NVML_MOCK_DIR="$NVML_MOCK_DIR" mock_nvml/mockctl.sh tail-log
+   # In each extra shell, export the value printed in step 1 so the helper targets the same directory.
+   export NVML_MOCK_DIR=/tmp/tmp.XYZ123  # replace with the path from the printf above
+   mock_nvml/mockctl.sh set-temp 35
+   mock_nvml/mockctl.sh set-temp 70
+   mock_nvml/mockctl.sh tail-log
    ```
    Each call to `set-temp` updates the value the daemon reads on the next
    iteration. `tail-log` shows the speeds the daemon asked the mock library to
@@ -125,17 +129,27 @@ changes without a rebuild:
    the mock backend as shown above. Capture its PID:
    ```sh
    TMPDIR=$(mktemp -d)
-   CONFIG_PATH="$TMPDIR/nvfc.conf"
-   mkdir -p "$TMPDIR/mock"
+   export CONFIG_PATH="$TMPDIR/nvfc.conf"
+   export NVML_MOCK_DIR="$TMPDIR/mock"
+   mkdir -p "$NVML_MOCK_DIR"
    cp tests/reload_initial.conf "$CONFIG_PATH"
+   # Save the exports so other shells can simply `source "$TMPDIR/env.sh"`.
+   printf 'export NVML_MOCK_DIR=%q\nexport CONFIG_PATH=%q\n' "$NVML_MOCK_DIR" "$CONFIG_PATH" > "$TMPDIR/env.sh"
    USE_MOCK_NVML=1 make build
-   NVML_MOCK_DIR="$TMPDIR/mock" NVFC_CONFIG_PATH="$CONFIG_PATH" ./build/nvidia_fan_controlV2d &
+   NVFC_CONFIG_PATH="$CONFIG_PATH" ./build/nvidia_fan_controlV2d &
    DAEMON_PID=$!
    ```
 2. In a second terminal, launch the TUI directly against that config, edit a
    point, and save:
    ```sh
+   source "$TMPDIR/env.sh"
    python3 tui/nvfc_tui.py --config "$CONFIG_PATH"
+   ```
+   You can also reuse the sourced environment to drive the mock daemon while
+   editing:
+   ```sh
+   mock_nvml/mockctl.sh set-temp 55
+   mock_nvml/mockctl.sh tail-log
    ```
 3. Signal the running daemon so it reloads the updated curve:
    ```sh

--- a/tui/nvfc_tui.py
+++ b/tui/nvfc_tui.py
@@ -152,7 +152,9 @@ def load_config(path: str) -> CurveState:
 
 
 def save_config(path: str, state: CurveState) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    dirpath = os.path.dirname(path)
+    if dirpath:
+        os.makedirs(dirpath, exist_ok=True)
     parser = configparser.ConfigParser()
     parser["curve"] = {
         "temps": ",".join(str(x) for x in state.temps),
@@ -586,7 +588,11 @@ def main() -> int:
     parser.add_argument("--config", default=CONFIG_PATH, help="Path to configuration file (default: %(default)s)")
     args = parser.parse_args()
 
-    state = load_config(args.config)
+    config_path = args.config.strip()
+    if not config_path:
+        parser.error("--config requires a non-empty path. Set NVFC_CONFIG_PATH or pass an explicit location.")
+
+    state = load_config(config_path)
     curses.stdscr = None  # type: ignore[attr-defined]
 
     def wrapper(stdscr: "curses._CursesWindow") -> Tuple[bool, CurveState]:
@@ -601,8 +607,8 @@ def main() -> int:
         if not valid:
             print(f"Failed to save: {err}")
             return 1
-        save_config(args.config, final_state)
-        print(f"Configuration saved to {args.config}")
+        save_config(config_path, final_state)
+        print(f"Configuration saved to {config_path}")
         return 0
     print("No changes saved.")
     return 1


### PR DESCRIPTION
## Summary
- document how to re-use the mock NVML directory and config path across terminals during manual testing drills
- ensure the TUI refuses empty --config values and skips directory creation for bare filenames

## Testing
- python3 -m compileall tui/nvfc_tui.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691761d6a2d48323b7748d1d3179265d)