### PR TITLE
Add helper script for mock reload drill

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,73 +84,33 @@ scripts end-to-end.
 - The mock library logs fan updates under `${NVML_MOCK_DIR:-/tmp/nvml-mock}/fan_speed.log`
   for manual inspection.
 
-### Manual Mock Session
-Follow these steps to drive the daemon by hand with synthetic temperatures:
-
-1. Build against the mock NVML library and pick a scratch directory:
-   ```sh
-   USE_MOCK_NVML=1 make build
-   export NVML_MOCK_DIR="$(mktemp -d)"
-   # Copy this export line into any additional shells that need to talk to the mock backend.
-   printf 'export NVML_MOCK_DIR=%q\n' "$NVML_MOCK_DIR"
-   ```
-2. Launch the daemon with any config (the test fixtures are handy starting
-   points):
-   ```sh
-   NVML_MOCK_DIR="$NVML_MOCK_DIR" ./build/nvidia_fan_controlV2d --config tests/reload_initial.conf &
-   DAEMON_PID=$!
-   ```
-3. In another terminal, set fake temperatures and tail the mock fan-speed log
-   using the helper script:
-   ```sh
-   # In each extra shell, export the value printed in step 1 so the helper targets the same directory.
-   export NVML_MOCK_DIR=/tmp/tmp.XYZ123  # replace with the path from the printf above
-   mock_nvml/mockctl.sh set-temp 35
-   mock_nvml/mockctl.sh set-temp 70
-   mock_nvml/mockctl.sh tail-log
-   ```
-   Each call to `set-temp` updates the value the daemon reads on the next
-   iteration. `tail-log` shows the speeds the daemon asked the mock library to
-   apply, mirroring what the automated tests assert.
-4. When finished, stop the daemon and clean up:
-   ```sh
-   kill "$DAEMON_PID"
-   rm -rf "$NVML_MOCK_DIR"
-   ```
-
-The helper script also supports `set-fans` to emulate multi-fan boards if you
-need to exercise that codepath during manual testing.
-
 ### Manual Reload / Reconfigure Drill
 You can confirm that editing the config file and signalling the daemon applies
-changes without a rebuild:
+changes without a rebuild by running the helper script:
 
-1. Create a temporary working directory and config, then start the daemon using
-   the mock backend as shown above. Capture its PID:
-   ```sh
-   TMPDIR=$(mktemp -d)
-   export CONFIG_PATH="$TMPDIR/nvfc.conf"
-   export NVML_MOCK_DIR="$TMPDIR/mock"
-   mkdir -p "$NVML_MOCK_DIR"
-   cp tests/reload_initial.conf "$CONFIG_PATH"
-   # Save the exports so other shells can simply `source "$TMPDIR/env.sh"`.
-   echo '##################'
-   echo 'RUN THE BELOW COMMAND IN THE OTHER TERMINAL'
-   printf 'export TMPDIR=%q\n' "$TMPDIR"
-   printf 'export NVML_MOCK_DIR=%q\nexport CONFIG_PATH=%q\n' "$NVML_MOCK_DIR" "$CONFIG_PATH" > "$TMPDIR/env.sh"
-   USE_MOCK_NVML=1 make build
-   NVFC_CONFIG_PATH="$CONFIG_PATH" ./build/nvidia_fan_controlV2d &
-   DAEMON_PID=$!
-   printf 'export DAEMON_PID=%q\n' "$DAEMON_PID" >> "$TMPDIR/env.sh"
-   ```
-2. In a second terminal, launch the TUI directly against that config, edit a
-   point, and save:
+```sh
+./scripts/mock_reconfigure_drill.sh
+```
+
+The script performs the following steps:
+
+- Builds the daemon against the mock NVML library (`USE_MOCK_NVML=1 make build`).
+- Creates an isolated scratch directory containing the default six-point curve
+  from `tests/reload_initial.conf` (the same values the daemon falls back to
+  when parsing fails).
+- Starts the daemon in the background with stdout/err captured to
+  `$TMPDIR/daemon.log` and writes an environment helper to `$TMPDIR/env.sh` so
+  additional terminals can join the session (`source "$TMPDIR/env.sh"`).
+
+Once the script prints the session banner, you can:
+
+1. Launch the TUI against the generated config:
    ```sh
    source "$TMPDIR/env.sh"
    python3 tui/nvfc_tui.py --config "$CONFIG_PATH"
    ```
-   You can also reuse the sourced environment to drive the mock daemon while
-   editing:
+   Edit a point and save to write the updated curve.
+2. Drive the mock daemon while the TUI is open:
    ```sh
    mock_nvml/mockctl.sh set-temp 55
    mock_nvml/mockctl.sh tail-log
@@ -159,9 +119,9 @@ changes without a rebuild:
    ```sh
    kill -HUP "$DAEMON_PID"
    ```
-4. Watch the daemon log (or the mock `fan_speed.log`) to confirm the
-   `Reloaded config` message and the new speeds taking effect. When finished,
-   stop the process and delete the scratch directory:
+4. Inspect `$TMPDIR/daemon.log` or the mock `fan_speed.log` for the
+   `Reloaded config` message and new speeds. When finished, stop the process and
+   delete the scratch directory:
    ```sh
    kill "$DAEMON_PID"
    rm -rf "$TMPDIR"

--- a/scripts/mock_reconfigure_drill.sh
+++ b/scripts/mock_reconfigure_drill.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=${ROOT_DIR:-$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)}
+
+SESSION_DIR=$(mktemp -d "${TMPDIR:-/tmp}/nvfc-drill.XXXXXX")
+CONFIG_PATH="$SESSION_DIR/nvfc.conf"
+MOCK_DIR="$SESSION_DIR/mock"
+LOG_PATH="$SESSION_DIR/daemon.log"
+ENV_PATH="$SESSION_DIR/env.sh"
+
+mkdir -p "$MOCK_DIR"
+cp "$ROOT_DIR/tests/reload_initial.conf" "$CONFIG_PATH"
+
+{
+  printf 'export TMPDIR=%q\n' "$SESSION_DIR"
+  printf 'export NVML_MOCK_DIR=%q\n' "$MOCK_DIR"
+  printf 'export CONFIG_PATH=%q\n' "$CONFIG_PATH"
+  printf 'export NVFC_CONFIG_PATH=%q\n' "$CONFIG_PATH"
+} >"$ENV_PATH"
+
+pushd "$ROOT_DIR" >/dev/null
+USE_MOCK_NVML=1 make build
+nohup env NVML_MOCK_DIR="$MOCK_DIR" NVFC_CONFIG_PATH="$CONFIG_PATH" \
+  ./build/nvidia_fan_controlV2d >"$LOG_PATH" 2>&1 &
+DAEMON_PID=$!
+popd >/dev/null
+
+printf 'export DAEMON_PID=%q\n' "$DAEMON_PID" >>"$ENV_PATH"
+
+cat <<MESSAGE
+################################################################################
+# NVIDIA Fan Control V2 – Mock Reload Drill                                    #
+################################################################################
+
+Scratch directory : $SESSION_DIR
+Config path       : $CONFIG_PATH
+Mock NVML dir     : $MOCK_DIR
+Daemon PID        : $DAEMON_PID
+Daemon log        : $LOG_PATH
+Helper env file   : $ENV_PATH
+
+To join the session in another shell:
+  source "$ENV_PATH"
+
+Then run the TUI against the config, edit, and save:
+  python3 $ROOT_DIR/tui/nvfc_tui.py --config "\$CONFIG_PATH"
+
+Drive the mock backend while editing:
+  $ROOT_DIR/mock_nvml/mockctl.sh set-temp 55
+  $ROOT_DIR/mock_nvml/mockctl.sh tail-log
+
+Apply the new curve without rebuilding:
+  kill -HUP "\$DAEMON_PID"
+
+Inspect the daemon output:
+  tail -f "$LOG_PATH"
+
+When finished, stop the daemon and clean up:
+  kill "\$DAEMON_PID"
+  rm -rf "$SESSION_DIR"
+
+Enjoy the reload drill!
+MESSAGE

--- a/tests/reload_initial.conf
+++ b/tests/reload_initial.conf
@@ -1,6 +1,6 @@
 [curve]
-temps = 0,40,80
-speeds = 30,40,60
+temps = 0,40,55,67,75,85
+speeds = 25,30,45,65,78,99
 
 [run]
 gpu_index = 0

--- a/tests/test_reload.sh
+++ b/tests/test_reload.sh
@@ -42,7 +42,7 @@ if ! grep -q "Reloaded config" "$LOG_PATH"; then
   exit 1
 fi
 
-if ! grep -q "speed=60" "$MOCK_DIR/fan_speed.log"; then
+if ! grep -q "speed=78" "$MOCK_DIR/fan_speed.log"; then
   echo "Expected initial speed entry" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- replace the manual mock walkthrough in the README with instructions for the new helper script
- add scripts/mock_reconfigure_drill.sh to stage the reload drill using the default six-point curve
- update the reload fixtures/tests so the mock session starts from the daemon defaults

## Testing
- USE_MOCK_NVML=1 make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176c41151083238799386426678edc)